### PR TITLE
Add icon option to file tree

### DIFF
--- a/scitree/__main__.py
+++ b/scitree/__main__.py
@@ -27,6 +27,11 @@ def main():
         action="store_true",
         help="Show files and folders from gitignore file.",
     )
+    parser.add_argument(
+        "-e",
+        action="store_true",
+        help="Add icons to files and folders.",
+    )
     # version
     parser.add_argument(
         "-V",
@@ -44,6 +49,8 @@ def main():
 
     if not args.a:
         options["exclude_folders"] = [".git"]
+
+    options["icons"] = args.e
 
     scitree(args.dir, **options)
 

--- a/scitree/styling.py
+++ b/scitree/styling.py
@@ -1,12 +1,21 @@
 from pathlib import Path
 
+# colors are blue, green, red, yellow
 SCRIPT_COLOR = 31
 README_COLOR = 34
 DATA_COLOR = 32
+FIGURE_COLOR = 33
+FOLDER_COLOR = 30
 
-CODE_SUFFIXES = [".py", ".R", ".m", ".js", ".sh", ".ipynb", ".cpp", ".h"]
+SCRIPT_ICON = '\U0001F4C4'  # 📄
+README_ICON = '\U0001F4D6'  # 📖
+DATA_ICON = '\U0001F4DC'    # 📜
+FIGURE_ICON = '\U0001F4CA'  # 📊
+FOLDER_ICON = '\U0001F4C1'  # 📁
 
-DATA_SUFFIXES = [".csv", ".tab", ".xlsx", ".xls", ".json", ".zip", ".dat"]
+CODE_SUFFIXES = [".py", ".R", ".m", ".js", ".sh", ".ipynb", ".cpp", ".h", ".bat"]
+DATA_SUFFIXES = [".csv", ".tab", ".xlsx", ".xls", ".json", ".zip", ".dat" ".txt", ".tsv"]
+FIGURE_SUFFIXES = [".png", ".jpg", ".jpeg", ".svg", ".pdf", ".eps", ".tiff", ".tif" ".gif" ".bmp"]
 
 
 def _color(style, ftype, color=31, inner=True):
@@ -41,12 +50,32 @@ def _color_file(style, color=31, inner=True):
     return _color(style=style, ftype="file", color=color, inner=inner)
 
 
-def _color_folder(style, color=31, inner=True):
+def _color_folder(style, color=30, inner=True):
 
     return _color(style=style, ftype="folder", color=color, inner=inner)
 
 
-def natsort_scitree_style(item):
+def _icon_file(style, icon=SCRIPT_ICON):
+
+    if "filestart" in style:
+        style["filestart"] = icon + " " + style["filestart"]
+    else:
+        style["filestart"] = icon + " "
+
+    return style
+
+
+def _icon_folder(style, icon=FOLDER_ICON):
+
+    if "folderstart" in style:
+        style["folderstart"] = icon + " " + style["folderstart"]
+    else:
+        style["folderstart"] = icon + " "
+
+    return style
+
+
+def natsort_scitree_style(item, **kwargs):
 
     # convert to Path
     item = Path(item)
@@ -61,11 +90,26 @@ def natsort_scitree_style(item):
 
     if item.suffix in CODE_SUFFIXES:
         style = _color_file(style, color=SCRIPT_COLOR)
+        if kwargs.get("icons", True):
+            style = _icon_file(style, icon=SCRIPT_ICON)
 
     if item.suffix in DATA_SUFFIXES:
         style = _color_file(style, color=DATA_COLOR)
+        if kwargs.get("icons", True):
+            style = _icon_file(style, icon=DATA_ICON)
+
+    if item.suffix in FIGURE_SUFFIXES:
+        style = _color_file(style, color=FIGURE_COLOR)
+        if kwargs.get("icons", True):
+            style = _icon_file(style, icon=FIGURE_ICON)
 
     if item.stem.lower().startswith("readme"):
         style = _color_file(style, color=README_COLOR)
+        if kwargs.get("icons", True):
+            style = _icon_file(style, icon=README_ICON)
+
+    if item.is_dir():
+        if kwargs.get("icons", True):
+            style = _icon_folder(style, icon=FOLDER_ICON)
 
     return style

--- a/scitree/styling.py
+++ b/scitree/styling.py
@@ -6,16 +6,20 @@ README_COLOR = 34
 DATA_COLOR = 32
 FIGURE_COLOR = 33
 FOLDER_COLOR = 30
+SERIAL_COLOR = 35   # magenta
 
 SCRIPT_ICON = '\U0001F4C4'  # 📄
 README_ICON = '\U0001F4D6'  # 📖
 DATA_ICON = '\U0001F4DC'    # 📜
 FIGURE_ICON = '\U0001F4CA'  # 📊
 FOLDER_ICON = '\U0001F4C1'  # 📁
+SERIAL_ICON = '\U0001F4E6'  # 📦
 
 CODE_SUFFIXES = [".py", ".R", ".m", ".js", ".sh", ".ipynb", ".cpp", ".h", ".bat"]
 DATA_SUFFIXES = [".csv", ".tab", ".xlsx", ".xls", ".json", ".zip", ".dat" ".txt", ".tsv"]
 FIGURE_SUFFIXES = [".png", ".jpg", ".jpeg", ".svg", ".pdf", ".eps", ".tiff", ".tif" ".gif" ".bmp"]
+SERIALDATA_SUFFIXES = [".rds", ".pkl", ".bin", ".h5", ".hdf5",
+                       ".mat", ".sav", ".dta", ".sas7bdat", ".feather", ".parquet"]
 
 
 def _color(style, ftype, color=31, inner=True):
@@ -102,6 +106,11 @@ def natsort_scitree_style(item, **kwargs):
         style = _color_file(style, color=FIGURE_COLOR)
         if kwargs.get("icons", True):
             style = _icon_file(style, icon=FIGURE_ICON)
+
+    if item.suffix in SERIALDATA_SUFFIXES:
+        style = _color_file(style, color=SERIAL_COLOR)
+        if kwargs.get("icons", True):
+            style = _icon_file(style, icon=SERIAL_ICON)
 
     if item.stem.lower().startswith("readme"):
         style = _color_file(style, color=README_COLOR)

--- a/scitree/styling.py
+++ b/scitree/styling.py
@@ -1,11 +1,10 @@
 from pathlib import Path
 
 # colors are blue, green, red, yellow
-SCRIPT_COLOR = 31
-README_COLOR = 34
-DATA_COLOR = 32
-FIGURE_COLOR = 33
-FOLDER_COLOR = 30
+SCRIPT_COLOR = 31   # red
+README_COLOR = 34   # blue
+DATA_COLOR = 32     # green
+FIGURE_COLOR = 33   # yellow
 SERIAL_COLOR = 35   # magenta
 
 SCRIPT_ICON = '\U0001F4C4'  # 📄
@@ -16,7 +15,7 @@ FOLDER_ICON = '\U0001F4C1'  # 📁
 SERIAL_ICON = '\U0001F4E6'  # 📦
 
 CODE_SUFFIXES = [".py", ".R", ".m", ".js", ".sh", ".ipynb", ".cpp", ".h", ".bat"]
-DATA_SUFFIXES = [".csv", ".tab", ".xlsx", ".xls", ".json", ".zip", ".dat" ".txt", ".tsv"]
+DATA_SUFFIXES = [".csv", ".tab", ".xlsx", ".xls", ".json", ".zip", ".dat" ".txt", ".tsv", ".ods"]
 FIGURE_SUFFIXES = [".png", ".jpg", ".jpeg", ".svg", ".pdf", ".eps", ".tiff", ".tif" ".gif" ".bmp"]
 SERIALDATA_SUFFIXES = [".rds", ".pkl", ".bin", ".h5", ".hdf5",
                        ".mat", ".sav", ".dta", ".sas7bdat", ".feather", ".parquet"]

--- a/scitree/tree.py
+++ b/scitree/tree.py
@@ -8,6 +8,11 @@ from scitree.styling import DATA_COLOR
 from scitree.styling import README_COLOR
 from scitree.styling import SCRIPT_COLOR
 from scitree.styling import FIGURE_COLOR
+from scitree.styling import DATA_ICON
+from scitree.styling import README_ICON
+from scitree.styling import SCRIPT_ICON
+from scitree.styling import FIGURE_ICON
+
 from scitree.styling import natsort_scitree_style
 
 
@@ -73,5 +78,5 @@ def scitree(
     )
 
     print(f"\n{n_folders} directories, {n_files} files")
-    print(f"\x1b[{README_COLOR}mREADME\x1b[0m \x1b[{DATA_COLOR}mData\x1b[0m \x1b[{SCRIPT_COLOR}mCode\x1b[0m \x1b[{FIGURE_COLOR}mFigures\x1b[0m")  # noqa
+    print(f"{README_ICON}\x1b[{README_COLOR}mREADME {DATA_ICON}\x1b[0m \x1b[{DATA_COLOR}mData\x1b[0m {SCRIPT_ICON}\x1b[{SCRIPT_COLOR}mCode\x1b[0m {FIGURE_ICON}\x1b[{FIGURE_COLOR}mFigures\x1b[0m")  # noqa
 

--- a/scitree/tree.py
+++ b/scitree/tree.py
@@ -80,7 +80,7 @@ def scitree(
         exclude_folders=exclude_folders,
     )
 
-    print(f"\n{n_folders} directories, {n_files} files")
+    print(f"\n{n_folders} {'directory' if n_folders == 1 else 'directories'} , {n_files} files")
     print(f"""\
 {README_ICON if icons else ''}\x1b[{README_COLOR}mREADME \x1b[0m\
 {DATA_ICON if icons else ''}\x1b[{DATA_COLOR}mData \x1b[0m\

--- a/scitree/tree.py
+++ b/scitree/tree.py
@@ -13,6 +13,7 @@ from scitree.styling import DATA_ICON
 from scitree.styling import README_ICON
 from scitree.styling import SCRIPT_ICON
 from scitree.styling import FIGURE_ICON
+from scitree.styling import FOLDER_ICON
 from scitree.styling import SERIAL_ICON
 
 from scitree.styling import natsort_scitree_style

--- a/scitree/tree.py
+++ b/scitree/tree.py
@@ -48,7 +48,7 @@ def scitree(
     gitignore=True,
     first="files",
     exclude_folders=[".git"],
-    icons=True,
+    icons=False,
     **kwargs
 ):
 
@@ -65,7 +65,7 @@ def scitree(
         str(p),
         sort=sort,
         sort_key=sort_key,
-        formatter=formatter,
+        formatter=lambda item: formatter(item, icons=icons),
         first=first,
         mask=gi_mask,
         exclude_folders=exclude_folders,

--- a/scitree/tree.py
+++ b/scitree/tree.py
@@ -81,4 +81,11 @@ def scitree(
     )
 
     print(f"\n{n_folders} directories, {n_files} files")
-    print(f"{README_ICON}\x1b[{README_COLOR}mREADME {DATA_ICON}\x1b[0m \x1b[{DATA_COLOR}mData\x1b[0m {SCRIPT_ICON}\x1b[{SCRIPT_COLOR}mCode\x1b[0m {FIGURE_ICON}\x1b[{FIGURE_COLOR}mFigures\x1b[0m {FOLDER_ICON}Folder {SERIAL_ICON}\x1b[{SERIAL_COLOR}mSerial Data ")  # noqa
+    print(f"""\
+{README_ICON if icons else ''}\x1b[{README_COLOR}mREADME \x1b[0m\
+{DATA_ICON if icons else ''}\x1b[{DATA_COLOR}mData \x1b[0m\
+{SCRIPT_ICON if icons else ''}\x1b[{SCRIPT_COLOR}mCode \x1b[0m\
+{FIGURE_ICON if icons else ''}\x1b[{FIGURE_COLOR}mFigures \x1b[0m\
+{SERIAL_ICON if icons else ''}\x1b[{SERIAL_COLOR}mSerial Data \x1b[0m\
+{FOLDER_ICON if icons else ''}Folder\
+    """)

--- a/scitree/tree.py
+++ b/scitree/tree.py
@@ -8,10 +8,12 @@ from scitree.styling import DATA_COLOR
 from scitree.styling import README_COLOR
 from scitree.styling import SCRIPT_COLOR
 from scitree.styling import FIGURE_COLOR
+from scitree.styling import SERIAL_COLOR
 from scitree.styling import DATA_ICON
 from scitree.styling import README_ICON
 from scitree.styling import SCRIPT_ICON
 from scitree.styling import FIGURE_ICON
+from scitree.styling import SERIAL_ICON
 
 from scitree.styling import natsort_scitree_style
 
@@ -78,5 +80,4 @@ def scitree(
     )
 
     print(f"\n{n_folders} directories, {n_files} files")
-    print(f"{README_ICON}\x1b[{README_COLOR}mREADME {DATA_ICON}\x1b[0m \x1b[{DATA_COLOR}mData\x1b[0m {SCRIPT_ICON}\x1b[{SCRIPT_COLOR}mCode\x1b[0m {FIGURE_ICON}\x1b[{FIGURE_COLOR}mFigures\x1b[0m")  # noqa
-
+    print(f"{README_ICON}\x1b[{README_COLOR}mREADME {DATA_ICON}\x1b[0m \x1b[{DATA_COLOR}mData\x1b[0m {SCRIPT_ICON}\x1b[{SCRIPT_COLOR}mCode\x1b[0m {FIGURE_ICON}\x1b[{FIGURE_COLOR}mFigures\x1b[0m {FOLDER_ICON}Folder {SERIAL_ICON}\x1b[{SERIAL_COLOR}mSerial Data ")  # noqa

--- a/scitree/tree.py
+++ b/scitree/tree.py
@@ -73,4 +73,5 @@ def scitree(
     )
 
     print(f"\n{n_folders} directories, {n_files} files")
+    print(f"\x1b[{README_COLOR}mREADME\x1b[0m \x1b[{DATA_COLOR}mData\x1b[0m \x1b[{SCRIPT_COLOR}mCode\x1b[0m \x1b[{FIGURE_COLOR}mFigures\x1b[0m")  # noqa
 

--- a/scitree/tree.py
+++ b/scitree/tree.py
@@ -7,6 +7,7 @@ import seedir as sd
 from scitree.styling import DATA_COLOR
 from scitree.styling import README_COLOR
 from scitree.styling import SCRIPT_COLOR
+from scitree.styling import FIGURE_COLOR
 from scitree.styling import natsort_scitree_style
 
 
@@ -39,6 +40,7 @@ def scitree(
     gitignore=True,
     first="files",
     exclude_folders=[".git"],
+    icons=True,
     **kwargs
 ):
 
@@ -71,4 +73,4 @@ def scitree(
     )
 
     print(f"\n{n_folders} directories, {n_files} files")
-    print(f"\x1b[{README_COLOR}mREADME\x1b[0m \x1b[{DATA_COLOR}mData\x1b[0m \x1b[{SCRIPT_COLOR}mCode\x1b[0m")  # noqa
+


### PR DESCRIPTION
I want to add a flag that adds icons to the file tree. Note that Seedir has a styling option for this, but as the styling options are overwritten in the formatter, it doesn't work for scitree.

Moreover, this implementation doesn't depend on the Emoji package.
 
In this PR
- Add icons
- Add icon flag `-e` for emoticon
- Add support for figures
- Add support for serial data
- Add .bat filetype to code_suffixes
- Adjust output text (directory detection, optional icons)